### PR TITLE
Add Gitstamp

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -71,6 +71,12 @@ All submitted publications can be read by everyone. An Arweave Wallet is require
     github: `coming soon`,
     link: `coming soon`,
   },
+  {
+    name: "Gitstamp",
+    description: `Timestamp your Git commits using the Arweave permaweb.`,
+    github: `https://github.com/artob/gitstamp.dev`,
+    link: `https://gitstamp.dev`,
+  },
 ]
 
 const fetchAppTransactions = appName =>


### PR DESCRIPTION
[Gitstamp](https://gitstamp.dev) adheres to the `App-Name` protocol as well:

<img alt="Screenshot of Gitstamp metadata" src="https://raw.githubusercontent.com/artob/gitstamp-action/master/sample.png" width="480"/>

- https://gitstamp.dev
- https://github.com/artob/gitstamp.dev
- https://github.com/artob/gitstamp-action
